### PR TITLE
Settings: Match pulse speed to frameworks default

### DIFF
--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -151,7 +151,7 @@
         <item>250</item>
         <item>500</item>
         <item>1000</item>
-        <item>2500</item>
+        <item>2000</item>
         <item>5000</item>
     </string-array>
 
@@ -167,7 +167,7 @@
         <item>250</item>
         <item>500</item>
         <item>1000</item>
-        <item>2500</item>
+        <item>2000</item>
         <item>5000</item>
     </string-array>
 


### PR DESCRIPTION
frameworks/base defines default LED timings:
 config_defaultNotificationLedOn = 500
 config_defaultNotificationLedOff = 2000

The LedOff timing of 2000 does not match any of the timings in the array
of notification_pulse_speed_values. So, a clean installation of
CyanogenMod results in an initial value of the notification pulse speed
being shown as "Custom". Reduce 2500ms in the pulse length and speed
arrays to 2000ms. Then, the default values for a new installation will
be: length = Short, speed = Slow.

This does have the side-effect of causing existing installations which
use 2500ms for either pulse length or speed now appearing as "Custom".

Change-Id: Idae42db93a0a329f33d6df6501427b509bc99272