### PR TITLE
Settings: fix up advanced mode logic

### DIFF
--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -1472,9 +1472,12 @@ public class SettingsActivity extends Activity
      * by default in an overlay.
      */
     public static boolean showAdvancedPreferences(Context context) {
-        return (android.provider.Settings.Secure.getInt(context.getContentResolver(),
-                android.provider.Settings.Secure.ADVANCED_MODE, 1) == 1)
-                && context.getResources().getBoolean(
+        final boolean forceAdvancedMode = context.getResources().getBoolean(
                 com.android.internal.R.bool.config_advancedSettingsMode);
+        if (forceAdvancedMode) {
+            return true;
+        }
+        return (android.provider.Settings.Secure.getInt(context.getContentResolver(),
+                android.provider.Settings.Secure.ADVANCED_MODE, 0) == 1);
     }
 }


### PR DESCRIPTION
The overlay config value should be a 'always-on' switch, otherwise
we should read the user-set setting.

Advanced mode should always be off by default.

Ref: CYNGNOS-815

Change-Id: I7f66eaf7fc84e9d3842e4ae874ffba2050b89ea6
Signed-off-by: Roman Birg <roman@cyngn.com>