### PR TITLE
settings: hide qs tiles with sensitive data

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -985,6 +985,7 @@
     <string name="qs_category_title">Quick Settings panel</string>
 
     <string name="qs_brightness_slider_title">Show brightness slider</string>
+    <string name="qs_hide_tiles_with_sensitive_data">Hide sensitive tiles when locked</string>
 
     <string name="qs_order_title">Select and order tiles</string>
     <string name="add_qs">Add new tile</string>

--- a/res/xml/notification_drawer_settings.xml
+++ b/res/xml/notification_drawer_settings.xml
@@ -15,6 +15,7 @@
      limitations under the License.
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings"
     android:title="@string/notification_drawer_title">
 
     <ListPreference
@@ -44,6 +45,12 @@
             android:summaryOn="@string/qs_main_tiles_summary_on"
             android:summaryOff="@string/qs_main_tiles_summary_off"
             android:defaultValue="true" />
+
+        <com.android.settings.cyanogenmod.SecureSettingSwitchPreference
+            android:key="lockscreen_hide_qs_tiles_with_sensitive_data"
+            android:title="@string/qs_hide_tiles_with_sensitive_data"
+            android:defaultValue="false"
+            settings:advanced="true"/>
 
         <com.android.settings.cyanogenmod.SecureSettingSwitchPreference
             android:key="qs_show_brightness_slider"


### PR DESCRIPTION
This changes add an option to respect the new sensitive data flag of the QS tiles when
lockscreen is showing and lockscreen is secure.

Requires: topic:hide-qs-tiles

JIRA: CML-140
JIRA: BACON-3519
JIRA: CYAN-6720
Signed-off-by: Jorge Ruesga <jorge@ruesga.com>
Signed-off-by: Adnan Begovic <adnan@cyngn.com>

Change-Id: I940d2353f92d8c4724d5d3dcb9860aec1dff288f