### PR TITLE
Long press no longer copies to clipboard if there is nothing to copy

### DIFF
--- a/src/com/android/settings/deviceinfo/Status.java
+++ b/src/com/android/settings/deviceinfo/Status.java
@@ -19,6 +19,7 @@ package com.android.settings.deviceinfo;
 import android.app.ActionBar;
 import android.bluetooth.BluetoothAdapter;
 import android.content.BroadcastReceiver;
+import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
@@ -414,14 +415,18 @@ public class Status extends PreferenceActivity {
                     ListAdapter listAdapter = (ListAdapter) parent.getAdapter();
                     Preference pref = (Preference) listAdapter.getItem(position);
 
-                    ClipboardManager cm = (ClipboardManager)
-                            getSystemService(Context.CLIPBOARD_SERVICE);
-                    cm.setText(pref.getSummary());
-                    Toast.makeText(
-                        Status.this,
-                        com.android.internal.R.string.text_copied,
-                        Toast.LENGTH_SHORT).show();
-                    return true;
+                    CharSequence summary = pref.getSummary();
+                    if (!TextUtils.isEmpty(summary)) {
+                        ClipboardManager cm = (ClipboardManager)
+                                getSystemService(Context.CLIPBOARD_SERVICE);
+                        cm.setPrimaryClip(ClipData.newPlainText(pref.getTitle(), summary));
+                        Toast.makeText(
+                                Status.this,
+                                com.android.internal.R.string.text_copied,
+                                Toast.LENGTH_SHORT).show();
+                        return true;
+                    }
+                    return false;
                 }
             });
 


### PR DESCRIPTION
Previously long pressing on e.g. 'SIM status' or 'IMEI information' would show a text
copied toast, but nothing was actually copied to the clipboard.

Change-Id: I3df82ff06c14134af01438ef3314d5def625880a