### PR TITLE
Settings: Only show multi-sim card configuration for owners

### DIFF
--- a/src/com/android/settings/Utils.java
+++ b/src/com/android/settings/Utils.java
@@ -1163,8 +1163,9 @@ public final class Utils {
     public static boolean showSimCardTile(Context context) {
         final TelephonyManager tm =
                 (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+        final boolean isPrimary = UserHandle.myUserId() == UserHandle.USER_OWNER;
 
-        return tm.getSimCount() > 1;
+        return tm.getSimCount() > 1 && isPrimary;
     }
 
     /**


### PR DESCRIPTION
Telephony only allows the owner to manage sim card Settings,
currently we are crashing when changing any multisim setting
from eithr a guest or non-owner. This patch addresses the
issue by not adding the tile unless the current user is the
owner.

Change-Id: Ifaeec6c22cdf7318530ef1e6ed6e1ec851317263
Ticket: CYNGNOS-879