### PR TITLE
Use default subscription's slot ID when showing SIM status

### DIFF
--- a/src/com/android/settings/deviceinfo/SimStatus.java
+++ b/src/com/android/settings/deviceinfo/SimStatus.java
@@ -135,7 +135,12 @@ public class SimStatus extends PreferenceActivity {
         // Note - missing in zaku build, be careful later...
         mSignalStrength = findPreference(KEY_SIGNAL_STRENGTH);
 
-        int slotId = getIntent().getIntExtra(EXTRA_SLOT_ID, 0);
+        int defaultSlotId = SubscriptionManager.getSlotId(SubscriptionManager.getDefaultSubId());
+        if (!SubscriptionManager.isValidSlotId(defaultSlotId)) {
+            defaultSlotId = 0;
+        }
+
+        int slotId = getIntent().getIntExtra(EXTRA_SLOT_ID, defaultSlotId);
         mSir = Utils.findRecordBySlotId(this, slotId);
 
         updatePhoneInfos();


### PR DESCRIPTION
* Don't default to slot 0 all the time, on multi-SIM devices, it is
  possible there is a single SIM in slot 1 instead.

REF: CYNGNOS-932
Change-Id: I6fe828411a593f699a375f485665f920d2cddbc5