### PR TITLE
Settings: Add security level default string

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -2151,6 +2151,8 @@
     <!-- About phone screen, status item label  [CHAR LIMIT=40] -->
     <string name="firmware_version">Android version</string>
     <!-- About phone screen, status item label  [CHAR LIMIT=40] -->
+    <string name="security_patch">Android security patch level</string>
+    <!-- About phone screen, status item label  [CHAR LIMIT=40] -->
     <string name="model_number">Model number</string>
     <!-- About phone screen, fcc equipment id label  [CHAR LIMIT=40] -->
     <string name="fcc_equipment_id">Equipment ID</string>


### PR DESCRIPTION
Commit 'Remove CM translations of security_patch' removed the redundant
CM strings for "Android security patch level", but a default value was
never actually provided by commit 'Add translations for Security Patch
Level.' Fix this.

Change-Id: I9089b4bdecfdfb472cbcae4f9bc8dc40b612fdd1
