### PR TITLE
Fix NPE.

### DIFF
--- a/src/com/android/settings/notification/IncreasingRingVolumePreference.java
+++ b/src/com/android/settings/notification/IncreasingRingVolumePreference.java
@@ -87,9 +87,11 @@ public class IncreasingRingVolumePreference extends Preference implements
 
     @Override
     public void onActivityStop() {
-        postStopSample();
-        mHandler.getLooper().quitSafely();
-        mHandler = null;
+        if (mHandler != null) {
+            postStopSample();
+            mHandler.getLooper().quitSafely();
+            mHandler = null;
+        }
     }
 
     @Override
@@ -205,7 +207,9 @@ public class IncreasingRingVolumePreference extends Preference implements
     }
 
     public void stopSample() {
-        postStopSample();
+        if (mHandler != null) {
+            postStopSample();
+        }
     }
 
     private void postStopSample() {


### PR DESCRIPTION
When entering the notification prefs sub activity without the increasing
ring pref being visible and leaving it right away, onActivityStop()
threw an NPE because the handler wasn't yet constructed.

Change-Id: Ia4291d8ac3d1dbf76d432db7e0e973844163c4ae
