### PR TITLE
Settings: Fix FC on Notification Light settings

### DIFF
--- a/src/com/android/settings/notificationlight/NotificationLightSettings.java
+++ b/src/com/android/settings/notificationlight/NotificationLightSettings.java
@@ -46,6 +46,7 @@ import com.android.settings.R;
 import com.android.settings.SettingsPreferenceFragment;
 import com.android.settings.cyanogenmod.PackageListAdapter;
 import com.android.settings.cyanogenmod.PackageListAdapter.PackageItem;
+import com.android.settings.cyanogenmod.CMSystemSettingSwitchPreference;
 import com.android.settings.cyanogenmod.SystemSettingSwitchPreference;
 
 import java.util.ArrayList;
@@ -73,7 +74,7 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
     private PackageManager mPackageManager;
     private PreferenceGroup mApplicationPrefList;
     private SystemSettingSwitchPreference mEnabledPref;
-    private SystemSettingSwitchPreference mCustomEnabledPref;
+    private CMSystemSettingSwitchPreference mCustomEnabledPref;
     private ApplicationLightPreference mDefaultPref;
     private ApplicationLightPreference mCallPref;
     private ApplicationLightPreference mVoicemailPref;
@@ -111,7 +112,7 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
         mEnabledPref = (SystemSettingSwitchPreference)
                 findPreference(Settings.System.NOTIFICATION_LIGHT_PULSE);
         mEnabledPref.setOnPreferenceChangeListener(this);
-        mCustomEnabledPref = (SystemSettingSwitchPreference)
+        mCustomEnabledPref = (CMSystemSettingSwitchPreference)
                 findPreference(CMSettings.System.NOTIFICATION_LIGHT_PULSE_CUSTOM_ENABLE);
         mCustomEnabledPref.setOnPreferenceChangeListener(this);
 


### PR DESCRIPTION
AndroidRuntime: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.android.settings/com.android.settings.SubSettings}: java.lang.ClassCastException: com.android.settings.cyanogenmod.CMSystemSettingSwitchPreference cannot be cast to com.android.settings.cyanogenmod.SystemSettingSwitchPreference

Change-Id: I3afa8bb4cfe9dcd76054b9c9bd9ba87a069f74e0
