### PR TITLE
Settings - Display Rotation: Checkboxes to Switches

### DIFF
--- a/res/xml/display_rotation.xml
+++ b/res/xml/display_rotation.xml
@@ -18,10 +18,10 @@
         android:title="@string/display_rotation_title"
         xmlns:settings="http://schemas.android.com/apk/res/com.android.settings">
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:key="accelerometer"
         android:title="@string/accelerometer_title" />
-    <CheckBoxPreference
+    <SwitchPreference
         android:key="lockscreen_rotation"
         android:title="@string/display_lockscreen_rotation_title"
         android:dependency="accelerometer" />

--- a/src/com/android/settings/cyanogenmod/DisplayRotation.java
+++ b/src/com/android/settings/cyanogenmod/DisplayRotation.java
@@ -23,6 +23,7 @@ import android.preference.CheckBoxPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceScreen;
+import android.preference.SwitchPreference;
 import android.provider.Settings;
 
 import com.android.internal.view.RotationPolicy;
@@ -41,7 +42,7 @@ public class DisplayRotation extends SettingsPreferenceFragment {
     private static final String ROTATION_180_PREF = "display_rotation_180";
     private static final String ROTATION_270_PREF = "display_rotation_270";
 
-    private CheckBoxPreference mAccelerometer;
+    private SwitchPreference mAccelerometer;
     private CheckBoxPreference mRotation0Pref;
     private CheckBoxPreference mRotation90Pref;
     private CheckBoxPreference mRotation180Pref;
@@ -55,7 +56,7 @@ public class DisplayRotation extends SettingsPreferenceFragment {
     private ContentObserver mAccelerometerRotationObserver = new ContentObserver(new Handler()) {
         @Override
         public void onChange(boolean selfChange) {
-            updateAccelerometerRotationCheckbox();
+            updateAccelerometerRotationSwitch();
         }
     };
 
@@ -67,7 +68,7 @@ public class DisplayRotation extends SettingsPreferenceFragment {
 
         PreferenceScreen prefSet = getPreferenceScreen();
 
-        mAccelerometer = (CheckBoxPreference) findPreference(KEY_ACCELEROMETER);
+        mAccelerometer = (SwitchPreference) findPreference(KEY_ACCELEROMETER);
         mAccelerometer.setPersistent(false);
 
         mRotation0Pref = (CheckBoxPreference) prefSet.findPreference(ROTATION_0_PREF);
@@ -89,7 +90,7 @@ public class DisplayRotation extends SettingsPreferenceFragment {
 //                com.android.internal.R.bool.config_hasRotationLockSwitch);
 
         if (hasRotationLock) {
-            // Disable accelerometer checkbox, but leave others enabled
+            // Disable accelerometer switch, but leave others enabled
             mAccelerometer.setEnabled(false);
             mRotation0Pref.setDependency(null);
             mRotation90Pref.setDependency(null);
@@ -97,8 +98,8 @@ public class DisplayRotation extends SettingsPreferenceFragment {
             mRotation270Pref.setDependency(null);
         }
 
-        final CheckBoxPreference lockScreenRotation =
-                (CheckBoxPreference) findPreference(KEY_LOCKSCREEN_ROTATION);
+        final SwitchPreference lockScreenRotation =
+                (SwitchPreference) findPreference(KEY_LOCKSCREEN_ROTATION);
         boolean canRotateLockscreen = getResources().getBoolean(
                 com.android.internal.R.bool.config_enableLockScreenRotation);
 
@@ -130,10 +131,10 @@ public class DisplayRotation extends SettingsPreferenceFragment {
     }
 
     private void updateState() {
-        updateAccelerometerRotationCheckbox();
+        updateAccelerometerRotationSwitch();
     }
 
-    private void updateAccelerometerRotationCheckbox() {
+    private void updateAccelerometerRotationSwitch() {
         mAccelerometer.setChecked(!RotationPolicy.isRotationLocked(getActivity()));
     }
 


### PR DESCRIPTION
Display rotation: Switches to checkboxes

According to the guidelines, checkboxes should be used in lists
Checkboxes match better than switches in this cas

Change-Id: I631c0ef65985d336e1a0790b6bb07ef7524ff6b2
Signed-off-by: STELIX ssspinni@gmail.com
