### PR TITLE
Fingerprint: Forward challenge extras

### DIFF
--- a/src/com/android/settings/ChooseLockPatternSize.java
+++ b/src/com/android/settings/ChooseLockPatternSize.java
@@ -79,6 +79,18 @@ public class ChooseLockPatternSize extends PreferenceActivity {
             intent.putExtra("confirm_credentials", false);
             intent.putExtra(LockPatternUtils.LOCKSCREEN_BIOMETRIC_WEAK_FALLBACK,
                     isFallback);
+
+            Intent originatingIntent = getActivity().getIntent();
+            // Forward the challenge extras if available in originating intent.
+            if (originatingIntent.hasExtra(ChooseLockSettingsHelper.EXTRA_KEY_HAS_CHALLENGE)) {
+                intent.putExtra(ChooseLockSettingsHelper.EXTRA_KEY_HAS_CHALLENGE,
+                        originatingIntent.getBooleanExtra(
+                                ChooseLockSettingsHelper.EXTRA_KEY_HAS_CHALLENGE, false));
+
+                intent.putExtra(ChooseLockSettingsHelper.EXTRA_KEY_CHALLENGE,
+                        originatingIntent.getLongExtra(
+                                ChooseLockSettingsHelper.EXTRA_KEY_CHALLENGE, 0));
+            }
             intent.addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT);
                     startActivity(intent);
 


### PR DESCRIPTION
The forward port of custom pattern sizes introduced a bug that would
cause an NPE when trying to add a fingerprint for security. This patch
forwards the extras associated with the challenge that would have
normally been passed directly in to the ChooseLockPattern fragment.

Change-Id: I3ad994b2604ff45b573c011c3588afe8b35bfdd3
TICKET: CYNGNOS-1490
